### PR TITLE
Update checkstyle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM openjdk:8-alpine
 
 ENV REVIEWDOG_VERSION=v0.10.0
 
-RUN wget -O - -q https://github.com/checkstyle/checkstyle/releases/download/checkstyle-8.32/checkstyle-8.32-all.jar > /checkstyle.jar
+RUN wget -O - -q https://github.com/checkstyle/checkstyle/releases/download/checkstyle-8.34/checkstyle-8.34-all.jar > /checkstyle.jar
 RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- -b /usr/local/bin/ ${REVIEWDOG_VERSION}
 RUN apk add --no-cache git
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
Update checkstyle to v8.34.

Release note for [v8.34](https://checkstyle.org/releasenotes.html#Release_8.34) and [v8.33](https://checkstyle.org/releasenotes.html#Release_8.33).