### PR TITLE
version bump to new LTS java version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-alpine
+FROM openjdk:17-alpine
 
 ENV REVIEWDOG_VERSION=v0.10.0
 


### PR DESCRIPTION
Closes: #28 

This switches the java version from java 8 to java17 so that checkstyle version 10 can be used