### PR TITLE
Fix for Git v2.35.2 spec changes

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,10 @@
 
 echo "Running check"
 
+cd "$GITHUB_WORKSPACE"
+
+git config --global --add safe.directory $GITHUB_WORKSPACE
+
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
 if [ -n "${INPUT_PROPERTIES_FILE}" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 echo "Running check"
 
-cd "$GITHUB_WORKSPACE"
+cd "${GITHUB_WORKSPACE}" || exit 1
 
 git config --global --add safe.directory $GITHUB_WORKSPACE
 


### PR DESCRIPTION
The GitHub Actions fails Due to Git v2.35.2 spec changes.

Fixes error thrown by reviewdog
```
reviewdog: PullRequest needs 'git' command: failed to run 'git rev-parse --show-prefix': exit status 128
```

See https://github.com/reviewdog/reviewdog/issues/1158 for more info