### PR TITLE
Bump checkstyle default version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ inputs:
     default: 'google_checks.xml'
   checkstyle_version:
     description: 'Checkstyle version'
-    default: '8.40'
+    default: '10.2'
   workdir:
     description: 'Working directory relative to the root directory.'
     default: '.'


### PR DESCRIPTION
This change aims to bump the default checkstyle version used from 8.40 to the latest one at the time.