### PR TITLE
Update entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,8 @@
 
 echo "Running check"
 
+command -v reviewdog >/dev/null 2>&1 || { echo >&2 "reviewdog: not found"; exit 1; }
+
 cd "${GITHUB_WORKSPACE}" || exit 1
 
 git config --global --add safe.directory $GITHUB_WORKSPACE
@@ -11,6 +13,8 @@ export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 if [ -n "${INPUT_PROPERTIES_FILE}" ]; then
   OPT_PROPERTIES_FILE="-p ${INPUT_PROPERTIES_FILE}"
 fi
+
+echo "Downloading checkstyle-${INPUT_CHECKSTYLE_VERSION}"
 
 wget -O - -q https://github.com/checkstyle/checkstyle/releases/download/checkstyle-${INPUT_CHECKSTYLE_VERSION}/checkstyle-${INPUT_CHECKSTYLE_VERSION}-all.jar > /checkstyle.jar
 


### PR DESCRIPTION
Add precondition detection: The installation of reviewdog in the container will fail if there is a network timeout. Therefore, if reviewdog does not exist, exit directly to avoid finding the problem after downloading checkstyle, which is a waste of time.

Downloading checkstyle theory also takes time. Before time-consuming operation (non-real-time response), output log feedback current process.

Here's the real problem I had
```bash
Running check
//I waited here for six minutes because of the network.
wget: error getting response: Resource temporarily unavailable
//In other words, it would take six minutes for me to know that there was a problem（reviewdog: not found） with the image build. The six-minute wait was completely useless.
/entrypoint.sh: line 18: reviewdog: not found
Error: Invalid or corrupt jarfile /checkstyle.jar
```