### PR TITLE
Dockerfile: use alternative image from eclipse-temurin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-alpine
+FROM eclipse-temurin:17-alpine
 
 ENV REVIEWDOG_VERSION=v0.14.0
 


### PR DESCRIPTION
https://github.com/nikitasavinov/checkstyle-action/issues/40

https://hub.docker.com/layers/library/eclipse-temurin/17-alpine/images/sha256-444fcc044076e6f4541e9dc4b5638ba396b2e90cf532341a48b7c342b6ada288