### PR TITLE
Replaces base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-alpine
+FROM openjdk:17-ea-alpine
 
 ENV REVIEWDOG_VERSION=v0.14.0
 


### PR DESCRIPTION
since openjdk:17-alpine seems to be no more available