### PR TITLE
Add Cursor Cloud dev environment setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,68 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### What this repo is
+
+This repository is a **Docker-based GitHub Action** (`checkstyle-action`) that runs
+[Checkstyle](https://github.com/checkstyle/checkstyle) on Java code and reports results via
+[reviewdog](https://github.com/reviewdog/reviewdog). See `README.md`, `action.yml`, `Dockerfile`,
+and `entrypoint.sh`.
+
+There is **no package manager, no test suite, no linter, and no dev server**. The only "build" is
+`docker build`, and the only way to "run" the product is to execute the container the way GitHub
+Actions would.
+
+### Docker daemon (required, not auto-started)
+
+Everything here needs Docker. The Docker engine is provisioned in the VM, but the daemon is **not**
+started automatically on boot. Start it once per session (needs sudo) before building/running:
+
+```bash
+sudo dockerd > /tmp/dockerd.log 2>&1 &
+# wait a few seconds, then verify:
+sudo docker info
+```
+
+Docker is configured (`/etc/docker/daemon.json`) with the `fuse-overlayfs` storage driver and
+`containerd-snapshotter` disabled — both are required for Docker to work in this VM (the kernel
+lacks full overlay2 support, and the containerd snapshotter is incompatible with fuse-overlayfs on
+Docker 29+). Do not remove that config.
+
+### Build
+
+```bash
+docker build . --file Dockerfile --tag checkstyle-action:local
+```
+
+> Egress caveat: the real `Dockerfile` runs `apk add --no-cache git`, which needs
+> `dl-cdn.alpinelinux.org` (all Alpine mirrors). That host is blocked by the default egress
+> allowlist in this VM, so the build fails at the `apk` step with a TLS/connection-reset error.
+> To fix, request `dl-cdn.alpinelinux.org` be added to the network allowlist. `github.com` and
+> `raw.githubusercontent.com` (used to fetch reviewdog and the Checkstyle JAR) are already allowed.
+> `git` is only used by `entrypoint.sh` for `git config --add safe.directory` and degrades
+> gracefully if absent, so a git-less image is enough to exercise the full check flow.
+
+### Run the action locally (no PR / no GitHub token needed)
+
+The action is normally driven by GitHub Actions env vars. To run it against any Java project locally,
+use reviewdog's `local` reporter with `nofilter` (there's no PR diff to filter against):
+
+```bash
+docker run --rm \
+  -e GITHUB_WORKSPACE=/github/workspace \
+  -e INPUT_CHECKSTYLE_CONFIG=google_checks.xml \
+  -e INPUT_CHECKSTYLE_VERSION=10.3 \
+  -e INPUT_WORKDIR=. \
+  -e INPUT_LEVEL=info \
+  -e INPUT_TOOL_NAME=checkstyle \
+  -e INPUT_REPORTER=local \
+  -e INPUT_FILTER_MODE=nofilter \
+  -e INPUT_FAIL_ON_ERROR=false \
+  -v "$(pwd)/your-java-project:/github/workspace" \
+  checkstyle-action:local
+```
+
+`google_checks.xml` and `sun_checks.xml` are bundled inside the Checkstyle JAR, so they resolve by
+name without a local file. Real CI usage instead sets `INPUT_GITHUB_TOKEN` and
+`INPUT_REPORTER=github-pr-check`/`github-pr-review` to post inline PR comments.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,13 +35,11 @@ Docker 29+). Do not remove that config.
 docker build . --file Dockerfile --tag checkstyle-action:local
 ```
 
-> Egress caveat: the real `Dockerfile` runs `apk add --no-cache git`, which needs
-> `dl-cdn.alpinelinux.org` (all Alpine mirrors). That host is blocked by the default egress
-> allowlist in this VM, so the build fails at the `apk` step with a TLS/connection-reset error.
-> To fix, request `dl-cdn.alpinelinux.org` be added to the network allowlist. `github.com` and
-> `raw.githubusercontent.com` (used to fetch reviewdog and the Checkstyle JAR) are already allowed.
-> `git` is only used by `entrypoint.sh` for `git config --add safe.directory` and degrades
-> gracefully if absent, so a git-less image is enough to exercise the full check flow.
+> Egress caveat: the `Dockerfile` fetches from `github.com` / `raw.githubusercontent.com`
+> (reviewdog + the Checkstyle JAR) and `dl-cdn.alpinelinux.org` (`apk add --no-cache git`). All
+> three are on the network allowlist for this environment. If a fresh VM ever blocks
+> `dl-cdn.alpinelinux.org` again, the build fails at the `apk add git` step with a
+> TLS/connection-reset error — re-request that domain in the network allowlist to unblock it.
 
 ### Run the action locally (no PR / no GitHub token needed)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and documents the development environment for this Docker-based GitHub Action (Checkstyle + reviewdog for Java). Adds `AGENTS.md` with durable Cursor Cloud instructions. No application code was modified.

## What this repo is

A Docker-based GitHub Action — no package manager, no test suite, no linter, no dev server. The only build step is `docker build`, and "running" it means executing the container the way GitHub Actions would.

## Environment setup performed

- Installed Docker (v29) in the VM and configured `/etc/docker/daemon.json` with `fuse-overlayfs` + `containerd-snapshotter` disabled (required for Docker to run in this VM).
- Started the Docker daemon and verified `docker info`.
- Allowlisted `dl-cdn.alpinelinux.org` so the real `Dockerfile`'s `apk add git` step succeeds.
- Built the **real, unmodified** `Dockerfile` and ran it end-to-end against a sample Java project.

## End-to-end verification (hello world)

Built `docker build . --file Dockerfile` (including `apk add git`) and ran the action against a sample Java file with intentional style violations, using reviewdog's `local` reporter. Checkstyle downloaded its JAR from GitHub, analyzed the file with `google_checks.xml`, and reviewdog reported 9 violations (no `git: not found` — git is present):

[real_image_run.log](https://cursor.com/agents/bc-6d580680-68c8-431e-b9a6-90d37e114925/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Freal_image_run.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6d580680-68c8-431e-b9a6-90d37e114925"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d580680-68c8-431e-b9a6-90d37e114925"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

